### PR TITLE
feat(chor): add bin executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ yarn add -D prisma-json-schema-generator
 
 ```prisma
 generator jsonSchema {
-  provider = "node node_modules/prisma-json-schema-generator"
+  provider = "prisma-json-schema-generator"
 }
 ```
 
 With a custom output path (default=./json-schema)
 ```prisma
 generator jsonSchema {
-  provider = "node node_modules/prisma-json-schema-generator"
+  provider = "prisma-json-schema-generator"
   output = "custom-output-path"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
     "singleQuote": true,
     "semi": false,
     "trailingComma": "all"
+  },
+  "bin": {
+    "prisma-json-schema-generator": "dist/cli.js"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import './index'


### PR DESCRIPTION
This MR adds bin executable into /node_modules/.bin/ folder after package is installed to simplify "provider" usage to just "prisma-json-schema-generator".