### PR TITLE
fix: add support for prisma ^2.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "url": "https://github.com/valentinpalkovic/prisma-json-schema-generator/issues"
   },
   "dependencies": {
-    "@prisma/generator-helper": "^2.20.0",
-    "@prisma/sdk": "^2.20.0",
+    "@prisma/generator-helper": "^2.20.1",
+    "@prisma/sdk": "^2.20.1",
     "core-js": "3.8.3"
   },
   "devDependencies": {
@@ -37,8 +37,8 @@
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-typescript": "^7.12.7",
-    "prisma": "^2.20.0",
-    "@prisma/client": "^2.20.0",
+    "prisma": "^2.20.1",
+    "@prisma/client": "^2.20.1",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/git": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "url": "https://github.com/valentinpalkovic/prisma-json-schema-generator/issues"
   },
   "dependencies": {
-    "@prisma/generator-helper": "^2.15.0",
-    "@prisma/sdk": "^2.15.0",
+    "@prisma/generator-helper": "^2.20.0",
+    "@prisma/sdk": "^2.20.0",
     "core-js": "3.8.3"
   },
   "devDependencies": {
@@ -37,8 +37,8 @@
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-typescript": "^7.12.7",
-    "@prisma/cli": "^2.15.0",
-    "@prisma/client": "^2.15.0",
+    "prisma": "^2.20.0",
+    "@prisma/client": "^2.20.0",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/git": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,37 +1236,30 @@
     "@octokit/openapi-types" "^2.3.1"
     "@types/node" ">= 8"
 
-"@prisma/cli@^2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.15.0.tgz#a979a67dbd606a966cf475686170128562590713"
-  integrity sha512-sF2mgn5oH5fL9/CKxS0tqojf0rK2BKODlEUqL+2s3YZqvJRSt4iFpiyjgajyd0wyTyv1k9LDHTV0yOD1mXDBsA==
+"@prisma/client@^2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.20.0.tgz#056ed756c2ea536b87771e79f68a984e94a452d8"
+  integrity sha512-WnYFD7JVs4nFyJyvOZc/fRQ6G+yLEXeANElX70hLlGHvi6YiruTDCXs/nryO8pTzdhg3//+ZynCvV+WHxV+sFg==
   dependencies:
-    "@prisma/engines" "2.15.0-25.e51dc3b5a9ee790a07104bec1c9477d51740fe54"
+    "@prisma/engines-version" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
 
-"@prisma/client@^2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.15.0.tgz#41ee22c60778b54aec0f6d4832c2d35fbf9eb423"
-  integrity sha512-3j4OoLpAGF104KAenUFJM9sU2+4jRP+RlrlYssBHkwBf+/5+2ihSpcmFiWIw1vXNRdmZtivjwhjcVtmjZPJktw==
-  dependencies:
-    "@prisma/engines-version" "2.15.0-25.e51dc3b5a9ee790a07104bec1c9477d51740fe54"
-
-"@prisma/debug@2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.15.0.tgz#942183e4ac596ef43f62858fa78ffdd7a25e0cb9"
-  integrity sha512-cnEXBGErbt5esQbiz6ioNNMKjDmhlN/WuUuSUB1KhiffyjAG8rxxQaAeH2LWCwaakORqiFzUtFygyZt1Sf7h7A==
+"@prisma/debug@2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.20.0.tgz#9f266da4f455a586d4a8c3e5af6050938f84e245"
+  integrity sha512-Q1K1ve2ic1BxevX4t1kTa6Vl0mhlKBRnjmYsRHW0UBxvNgpuIlKHNedyKSbQcx7n+adzbuLrICtFnUk25uS/LQ==
   dependencies:
     debug "4.3.2"
     ms "^2.1.3"
 
-"@prisma/engine-core@2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.15.0.tgz#b33c9fdae4615d9840d4a8a4b6c8248be94a9b7d"
-  integrity sha512-oO9w5ygbTiW7Q3WmZKH9vvIs5HduRyhaqEnzWt7hI/t28az8oN2HJ9x6ZGMF4ykGrkzG11m3NtFLuetePYZyqg==
+"@prisma/engine-core@2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.20.0.tgz#79c98dd70db4f2f795ddb5aacc950df61751a0d0"
+  integrity sha512-IMUT5EivkJ0kIzzaqoSsdXnyemztkaH7yPag++XRxkXZrZXfAwJnDUhotqJVb56uJAdKmswC3Je6cRb7N1/rAg==
   dependencies:
-    "@prisma/debug" "2.15.0"
-    "@prisma/engines" "2.15.0-25.e51dc3b5a9ee790a07104bec1c9477d51740fe54"
-    "@prisma/generator-helper" "2.15.0"
-    "@prisma/get-platform" "2.15.0"
+    "@prisma/debug" "2.20.0"
+    "@prisma/engines" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+    "@prisma/generator-helper" "2.20.0"
+    "@prisma/get-platform" "2.20.0"
     chalk "^4.0.0"
     execa "^5.0.0"
     get-stream "^6.0.0"
@@ -1274,25 +1267,25 @@
     new-github-issue-url "^0.2.1"
     p-retry "^4.2.0"
     terminal-link "^2.1.1"
-    undici "3.2.0"
+    undici "3.3.3"
 
-"@prisma/engines-version@2.15.0-25.e51dc3b5a9ee790a07104bec1c9477d51740fe54":
-  version "2.15.0-25.e51dc3b5a9ee790a07104bec1c9477d51740fe54"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.15.0-25.e51dc3b5a9ee790a07104bec1c9477d51740fe54.tgz#d9c887bc8f30d1f107c9021b2565a8672d62622d"
-  integrity sha512-KDxk7Zsc9tDoShCE7v+O1SnCUTUkMdfezjbuz9CBvdEBGMtYLgyHaZAO8M038uqy8KjgwV9PzyoLqvVfzfsngg==
+"@prisma/engines-version@2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e":
+  version "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e.tgz#1189f0a7e682f500015446cfe2b34d2753452190"
+  integrity sha512-fJhbGZXm2SPs/RsI79Ew4SFe+6QmChNdgU2I/SIjmU18bUgK8f1TBEWnVtFdBqEDHYPGxbpaianF7lp04KN7EA==
 
-"@prisma/engines@2.15.0-25.e51dc3b5a9ee790a07104bec1c9477d51740fe54":
-  version "2.15.0-25.e51dc3b5a9ee790a07104bec1c9477d51740fe54"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.15.0-25.e51dc3b5a9ee790a07104bec1c9477d51740fe54.tgz#3093ace7c09cf694214727c4e67109f2a2d8855a"
-  integrity sha512-AgPxAWtwYhhTNEEsV4lK63HTe9z0GAGL3ofMr2B0TncACmzi9lhdun9TTNie38Oy/3DLfr71TUHKUpV8QjOKUw==
+"@prisma/engines@2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e":
+  version "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e.tgz#18f23c4a8a335a93fd338f88c310f5cf120f5591"
+  integrity sha512-zOWETm7DTRvlwf/CekPNSeJe6EC5bn2IFexd74wM9zgBXCZo+1sMDuNGtCqIt4Rzv8CcimEgyzrEFVq0LPV8qg==
 
-"@prisma/fetch-engine@2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.15.0.tgz#7ec8e702d08679b8e7e648a6ad9cb233763ac7be"
-  integrity sha512-r/AR5vsVkjyY9BDh6pCXfHrBShwb71dwzQrB5iIVjyko5GapqJUCaocjGxSoWh3gqZD6pwZvYy/zxgX9wDGZOA==
+"@prisma/fetch-engine@2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.20.0.tgz#7495a99d189dd8ba37fb38ad2c365a1eab38f954"
+  integrity sha512-DY5y/OhaCJro1kF6Jy05zPwzL/aUfY82d/2osbCwgi9Kn0m1uKe5pUQ/EXAdI7FLPTimLnbDAkXhjv5A+50i8A==
   dependencies:
-    "@prisma/debug" "2.15.0"
-    "@prisma/get-platform" "2.15.0"
+    "@prisma/debug" "2.20.0"
+    "@prisma/get-platform" "2.20.0"
     chalk "^4.0.0"
     execa "^5.0.0"
     find-cache-dir "^3.3.1"
@@ -1309,39 +1302,39 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/generator-helper@2.15.0", "@prisma/generator-helper@^2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.15.0.tgz#c1d59d0c07f486cd7d8c759d83f94b4343e991b2"
-  integrity sha512-P7/EP4zQ25I8AxgDAoDCp+b6oi+rv8Xqm7MBjHY04TWuSgLLd8GCW7SLKwNDG6wDgDiX8mHcqThhsNPNSY3U1w==
+"@prisma/generator-helper@2.20.0", "@prisma/generator-helper@^2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.20.0.tgz#479a2a3b5c14303ebde4469908ce87a609e2f558"
+  integrity sha512-I66EwHKDsd9I4W3u2Iz2yFFkH7SdnTc5JarWALNeRyuKH4uzcoF9gnh/Yk2gmrb9flcam5jYZ241oNbLJ/5hpw==
   dependencies:
-    "@prisma/debug" "2.15.0"
+    "@prisma/debug" "2.20.0"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.15.0.tgz#b5439a23f9edd00337531d7bb463603593fa31f2"
-  integrity sha512-PTQ3G6d8Qcla7wyAt1czYXDUs/wM+hLSzsHt6OsGWhJJzG4jsJEiAp0xKlf++BqipIlZJCtp31VCJcsJO0g67A==
+"@prisma/get-platform@2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.20.0.tgz#fa16900265e4f313cf20cd83b9025a7231a064ea"
+  integrity sha512-tub8MbBc25ld667bRQ2OuvXXOx55TmYnu0jbeY3UvV1Y2ticCHWXN9AZX0r7kVSzDtFejRjEJa2H1Q579YwEyQ==
   dependencies:
-    "@prisma/debug" "2.15.0"
+    "@prisma/debug" "2.20.0"
 
-"@prisma/sdk@^2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.15.0.tgz#8e5bea392d0bf824670559a4989cdde0ae35cab2"
-  integrity sha512-p/P/dpDPUypCCJJyoNpeGH/MmRD12AaAhS4/Jaq3swcQsnTZyFlOY6LDn70i8MuE9inZfNYyc8XDxgnzxLvIxw==
+"@prisma/sdk@^2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.20.0.tgz#224ec3abe4bd773a2a21135598bdc99d61cb4d5c"
+  integrity sha512-BAFRaJKZUPxGJypewjfmO1QF+38NAaWKWN6gMmaWp7by02QMoS9auYdsB0eBPkOwXZPfJEJGNpCyn/cf/OLvrQ==
   dependencies:
-    "@prisma/debug" "2.15.0"
-    "@prisma/engine-core" "2.15.0"
-    "@prisma/engines" "2.15.0-25.e51dc3b5a9ee790a07104bec1c9477d51740fe54"
-    "@prisma/fetch-engine" "2.15.0"
-    "@prisma/generator-helper" "2.15.0"
-    "@prisma/get-platform" "2.15.0"
+    "@prisma/debug" "2.20.0"
+    "@prisma/engine-core" "2.20.0"
+    "@prisma/engines" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+    "@prisma/fetch-engine" "2.20.0"
+    "@prisma/generator-helper" "2.20.0"
+    "@prisma/get-platform" "2.20.0"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^5.0.0"
     chalk "4.1.0"
-    checkpoint-client "1.1.18"
+    checkpoint-client "1.1.19"
     cli-truncate "^2.1.0"
     dotenv "^8.2.0"
     execa "^5.0.0"
@@ -1349,13 +1342,14 @@
     global-dirs "^3.0.0"
     globby "^11.0.0"
     has-yarn "^2.1.0"
-    is-ci "^2.0.0"
+    is-ci "^3.0.0"
     make-dir "^3.0.2"
     node-fetch "2.6.1"
     p-map "^4.0.0"
     read-pkg-up "^7.0.1"
     resolve-pkg "^2.0.0"
     rimraf "^3.0.2"
+    shell-quote "^1.7.2"
     string-width "^4.2.0"
     strip-ansi "6.0.0"
     strip-indent "3.0.0"
@@ -2445,18 +2439,18 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-checkpoint-client@1.1.18:
-  version "1.1.18"
-  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.18.tgz#7ce9d0fe3601393603235fb514334cc5dc4cbcf8"
-  integrity sha512-tTvUGOs/0Hncjq3Ko9h9Yx8facRrMpKsYXDBo7vSkl+sFKL7bxU56rQektBeEK7WcaLzGNmP2UfRfWar5P9qXA==
+checkpoint-client@1.1.19:
+  version "1.1.19"
+  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.19.tgz#8a32bddbbc6acf6e20542f18780b71e5e0b981ed"
+  integrity sha512-aChSq/qsvyu3TXAJdtKgA03JxzUD/w3fwKpUhILPGFnHEO8OHx+cg6dgjuchQsIs2r3lSPPcwzgi21xohqTrmQ==
   dependencies:
-    ci-info "2.0.0"
+    ci-info "3.1.1"
     env-paths "2.2.0"
     fast-write-atomic "0.2.1"
     make-dir "3.1.0"
-    ms "2.1.2"
+    ms "2.1.3"
     node-fetch "2.6.1"
-    uuid "8.3.0"
+    uuid "8.3.2"
 
 chokidar@^3.4.0:
   version "3.5.1"
@@ -2483,15 +2477,20 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-ci-info@2.0.0, ci-info@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
-  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+ci-info@3.1.1, ci-info@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.1.1.tgz#9a32fcefdf7bcdb6f0a7e1c0f8098ec57897b80a"
+  integrity sha512-kdRWLBIJwdsYJWYJFtAFFYxybguqeF91qpZaggjG5Nf8QKdizFG2hjqvaTXbxFIcYbSaD74KpAXv6BSm17DHEQ==
 
 ci-info@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
   integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
+
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
 cidr-regex@^2.0.10:
   version "2.0.10"
@@ -4521,6 +4520,13 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
+is-ci@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.0.tgz#c7e7be3c9d8eef7d0fa144390bd1e4b88dc4c994"
+  integrity sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==
+  dependencies:
+    ci-info "^3.1.1"
+
 is-cidr@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/is-cidr/-/is-cidr-3.1.1.tgz#e92ef121bdec2782271a77ce487a8b8df3718ab7"
@@ -6068,7 +6074,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -6972,6 +6978,13 @@ prettysize@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettysize/-/prettysize-2.0.0.tgz#902c02480d865d9cc0813011c9feb4fa02ce6996"
   integrity sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==
 
+prisma@^2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.20.0.tgz#3b7562326f764b4785e92bc83741b91ff2264be7"
+  integrity sha512-z8zCFxOA4rVy49GHzxx886dDMTmM3oh6GPRvatujshTqJeD+znJS4sxekVfjmTp0zX1aO92wBd3J6yon5DE1jg==
+  dependencies:
+    "@prisma/engines" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -7694,6 +7707,11 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shell-quote@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
+  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
 shellwords@^0.1.1:
   version "0.1.1"
@@ -8539,10 +8557,10 @@ umask@^1.1.0, umask@~1.1.0:
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
   integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
 
-undici@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-3.2.0.tgz#62ef2336f25d965f321ac799db784ebeb8313ece"
-  integrity sha512-lBvV7jZirNtDbDmnDJTLbfFDJO6VDav76XRqILfeERlSnAWeYn5pAo6JdPc7OM55RiBZdsh8ucRG9TNfDrDnhg==
+undici@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-3.3.3.tgz#a90a783a5605fd3d0e093624e261aae234646452"
+  integrity sha512-JcC6p86DLPDne5vhm9nZ9N6hW/WPCtO8/NV+7YHS+x/mQ+NpWvtGxIt28ObBsySPec8FsabyiLPhmn7Htl9w3A==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -8708,20 +8726,15 @@ util-promisify@^2.1.0:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
 
-uuid@8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
-  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
+uuid@8.3.2, uuid@^8.3.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 uuid@^3.3.2, uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^8.3.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,30 +1236,30 @@
     "@octokit/openapi-types" "^2.3.1"
     "@types/node" ">= 8"
 
-"@prisma/client@^2.20.0":
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.20.0.tgz#056ed756c2ea536b87771e79f68a984e94a452d8"
-  integrity sha512-WnYFD7JVs4nFyJyvOZc/fRQ6G+yLEXeANElX70hLlGHvi6YiruTDCXs/nryO8pTzdhg3//+ZynCvV+WHxV+sFg==
+"@prisma/client@^2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.20.1.tgz#45e7bade3a1b58972fc35e511578e313ead18770"
+  integrity sha512-/IYPubBi55rNMHfE0wwglA6eTWEZD77oz+x+3Mm9ji2lDKdS1lnYKZ0wZX0E3AB8gTNL/zsGtfzmfjgn3ePyIw==
   dependencies:
     "@prisma/engines-version" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
 
-"@prisma/debug@2.20.0":
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.20.0.tgz#9f266da4f455a586d4a8c3e5af6050938f84e245"
-  integrity sha512-Q1K1ve2ic1BxevX4t1kTa6Vl0mhlKBRnjmYsRHW0UBxvNgpuIlKHNedyKSbQcx7n+adzbuLrICtFnUk25uS/LQ==
+"@prisma/debug@2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.20.1.tgz#cc7635188ad9be964738f0e2896cd24fb400bcef"
+  integrity sha512-/21PtPjusr+gFFTFe/HjQ7hxFfZEqZU8axFvP4xVX6CrXIjNEcUf6UKm1JbpbCKRwEEd6M040ovjS8jLAp253w==
   dependencies:
     debug "4.3.2"
     ms "^2.1.3"
 
-"@prisma/engine-core@2.20.0":
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.20.0.tgz#79c98dd70db4f2f795ddb5aacc950df61751a0d0"
-  integrity sha512-IMUT5EivkJ0kIzzaqoSsdXnyemztkaH7yPag++XRxkXZrZXfAwJnDUhotqJVb56uJAdKmswC3Je6cRb7N1/rAg==
+"@prisma/engine-core@2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.20.1.tgz#bcf1978eee080e7a4de6b43a9c917657fcbc176b"
+  integrity sha512-OQc8dVRZXJ9nrMs3s1DTHuq389CqcXFytm2CbqH/7L+LRWSdLm2pZOzuofhZ+Soh55/nGs82xUtarSAo5NKKuQ==
   dependencies:
-    "@prisma/debug" "2.20.0"
+    "@prisma/debug" "2.20.1"
     "@prisma/engines" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
-    "@prisma/generator-helper" "2.20.0"
-    "@prisma/get-platform" "2.20.0"
+    "@prisma/generator-helper" "2.20.1"
+    "@prisma/get-platform" "2.20.1"
     chalk "^4.0.0"
     execa "^5.0.0"
     get-stream "^6.0.0"
@@ -1279,13 +1279,13 @@
   resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e.tgz#18f23c4a8a335a93fd338f88c310f5cf120f5591"
   integrity sha512-zOWETm7DTRvlwf/CekPNSeJe6EC5bn2IFexd74wM9zgBXCZo+1sMDuNGtCqIt4Rzv8CcimEgyzrEFVq0LPV8qg==
 
-"@prisma/fetch-engine@2.20.0":
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.20.0.tgz#7495a99d189dd8ba37fb38ad2c365a1eab38f954"
-  integrity sha512-DY5y/OhaCJro1kF6Jy05zPwzL/aUfY82d/2osbCwgi9Kn0m1uKe5pUQ/EXAdI7FLPTimLnbDAkXhjv5A+50i8A==
+"@prisma/fetch-engine@2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.20.1.tgz#caee8aeb4ae661e31cbb2880dde4a306b360cd73"
+  integrity sha512-DWwozghLIkqQJ+jE6AF9lx+qwc9+0+bg0t3LOTDVpZsr00C23hsZXJyaNjz8x62/SbmxAqvPeatS3U+xXPE5Gg==
   dependencies:
-    "@prisma/debug" "2.20.0"
-    "@prisma/get-platform" "2.20.0"
+    "@prisma/debug" "2.20.1"
+    "@prisma/get-platform" "2.20.1"
     chalk "^4.0.0"
     execa "^5.0.0"
     find-cache-dir "^3.3.1"
@@ -1302,34 +1302,34 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/generator-helper@2.20.0", "@prisma/generator-helper@^2.20.0":
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.20.0.tgz#479a2a3b5c14303ebde4469908ce87a609e2f558"
-  integrity sha512-I66EwHKDsd9I4W3u2Iz2yFFkH7SdnTc5JarWALNeRyuKH4uzcoF9gnh/Yk2gmrb9flcam5jYZ241oNbLJ/5hpw==
+"@prisma/generator-helper@2.20.1", "@prisma/generator-helper@^2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.20.1.tgz#a94725876e1521becc4ef080904cff54dc641091"
+  integrity sha512-FY6D1Xu3uhaM0/qIg1P+P8U82HDKer418bCLJJU3IRd3XS/arybRGpZ4V3LGRgA8EmgCgOmvHDmnlFPDEhoODw==
   dependencies:
-    "@prisma/debug" "2.20.0"
+    "@prisma/debug" "2.20.1"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.20.0":
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.20.0.tgz#fa16900265e4f313cf20cd83b9025a7231a064ea"
-  integrity sha512-tub8MbBc25ld667bRQ2OuvXXOx55TmYnu0jbeY3UvV1Y2ticCHWXN9AZX0r7kVSzDtFejRjEJa2H1Q579YwEyQ==
+"@prisma/get-platform@2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.20.1.tgz#19cde8941c7c0cf387317bd43b7c99ba06aebc14"
+  integrity sha512-kb/qTAPLnIdaeYiW385Qs35xuPHpgN/qzqxtkh//z1GuiQ8Izdq4UmoqqAdC63R1ipRYw6TJPcLSMpKTM1JF2A==
   dependencies:
-    "@prisma/debug" "2.20.0"
+    "@prisma/debug" "2.20.1"
 
-"@prisma/sdk@^2.20.0":
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.20.0.tgz#224ec3abe4bd773a2a21135598bdc99d61cb4d5c"
-  integrity sha512-BAFRaJKZUPxGJypewjfmO1QF+38NAaWKWN6gMmaWp7by02QMoS9auYdsB0eBPkOwXZPfJEJGNpCyn/cf/OLvrQ==
+"@prisma/sdk@^2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.20.1.tgz#960b29c3fa7c12bf45dc6223ae0eb7d2755051f6"
+  integrity sha512-lu6WifrNBJAHwFsyu7brtrQWC3q4tSWNy6Dt+Z6+FBnXXMChASYK6Tkp9BzojlgfMS5XYHDXbIiBM1Bmxi/5Qg==
   dependencies:
-    "@prisma/debug" "2.20.0"
-    "@prisma/engine-core" "2.20.0"
+    "@prisma/debug" "2.20.1"
+    "@prisma/engine-core" "2.20.1"
     "@prisma/engines" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
-    "@prisma/fetch-engine" "2.20.0"
-    "@prisma/generator-helper" "2.20.0"
-    "@prisma/get-platform" "2.20.0"
+    "@prisma/fetch-engine" "2.20.1"
+    "@prisma/generator-helper" "2.20.1"
+    "@prisma/get-platform" "2.20.1"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^5.0.0"
@@ -6978,10 +6978,10 @@ prettysize@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettysize/-/prettysize-2.0.0.tgz#902c02480d865d9cc0813011c9feb4fa02ce6996"
   integrity sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==
 
-prisma@^2.20.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.20.0.tgz#3b7562326f764b4785e92bc83741b91ff2264be7"
-  integrity sha512-z8zCFxOA4rVy49GHzxx886dDMTmM3oh6GPRvatujshTqJeD+znJS4sxekVfjmTp0zX1aO92wBd3J6yon5DE1jg==
+prisma@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.20.1.tgz#28c52135523e0853258cd4ca7e883e9e4b5a9d40"
+  integrity sha512-zyPvJSUfJrmciP2D/4aUrsyIefiH8AIJUeuq1a0X1df1AFw9QQ+ata/7VQdoP+RIQHnCb6Kln9kqfUw/fieljw==
   dependencies:
     "@prisma/engines" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
 


### PR DESCRIPTION
# Breaking Change for custom generators
Hey Folks, In `2.20` the provider and the output for generators can now be env vars. This means these values will now be provided to you as an `Object` and not as a `string`. You can see the relevant changes below.
```ts
export interface EnvValue {
  fromEnvVar: null | string
  value: string
}
export interface GeneratorConfig {
  output: EnvValue | null # Changed from string | null
  provider: EnvValue # Changed from string
}
// There is a utility in the SDK to help you get the string value. 
import { parseEnvValue } from '@prisma/sdk'
// parseEnvValue(provider: EnvValue):string
```

## Note 
I have not tested this with previous versions of Prisma