### PR TITLE
feat: add option to keep relation scalar fields in json schema output

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ generator jsonSchema {
 }
 ```
 
+Additional options
+
+```prisma
+generator jsonSchema {
+  provider = "prisma-json-schema-generator"
+  keepRelationScalarFields = "true"
+}
+```
+
+The generator currently supports a single option
+
+| Key                      | Default Value   | Description                                                                                                                                                                                            |
+| ------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| keepRelationScalarFields | "false"         | By default, the JSON Schema that's generated will output only objects for related model records. If set to "true", this will cause the generator to also output foreign key fields for related records |
+
 **3. Run generation**
 
 prisma:

--- a/src/generator/model.ts
+++ b/src/generator/model.ts
@@ -1,7 +1,7 @@
 import { DMMF } from '@prisma/generator-helper'
 import { JSONSchema7Definition } from 'json-schema'
 import { getJSONSchemaProperty } from './properties'
-import { DefinitionMap, ModelMetaData } from './types'
+import { DefinitionMap, ModelMetaData, TransformOptions } from './types'
 
 function getRelationScalarFields(model: DMMF.Model): string[] {
     return model.fields.flatMap(
@@ -9,7 +9,10 @@ function getRelationScalarFields(model: DMMF.Model): string[] {
     )
 }
 
-export function getJSONSchemaModel(modelMetaData: ModelMetaData) {
+export function getJSONSchemaModel(
+    modelMetaData: ModelMetaData,
+    transformOptions: TransformOptions,
+) {
     return (model: DMMF.Model): DefinitionMap => {
         const definitionPropsMap = model.fields.map(
             getJSONSchemaProperty(modelMetaData),
@@ -25,7 +28,11 @@ export function getJSONSchemaModel(modelMetaData: ModelMetaData) {
                 -1,
         )
 
-        const properties = Object.fromEntries(propertiesWithoutRelationScalars)
+        const properties = Object.fromEntries(
+            transformOptions?.keepRelationScalarFields === 'true'
+                ? propertiesMap
+                : propertiesWithoutRelationScalars,
+        )
 
         const definition: JSONSchema7Definition = {
             type: 'object',

--- a/src/generator/transformDMMF.ts
+++ b/src/generator/transformDMMF.ts
@@ -1,5 +1,6 @@
 import type { DMMF } from '@prisma/generator-helper'
 import type { JSONSchema7, JSONSchema7Definition } from 'json-schema'
+import { TransformOptions } from './types'
 import { DEFINITIONS_ROOT } from './constants'
 import { toCamelCase } from './helpers'
 
@@ -17,11 +18,16 @@ function getPropertyDefinition(
     ]
 }
 
-export function transformDMMF(dmmf: DMMF.Document): JSONSchema7 {
+export function transformDMMF(
+    dmmf: DMMF.Document,
+    transformOptions: TransformOptions = {},
+): JSONSchema7 {
     const { models, enums } = dmmf.datamodel
     const initialJSON = getInitialJSON()
 
-    const modelDefinitionsMap = models.map(getJSONSchemaModel({ enums }))
+    const modelDefinitionsMap = models.map(
+        getJSONSchemaModel({ enums }, transformOptions),
+    )
     const modelPropertyDefinitionsMap = models.map(getPropertyDefinition)
     const definitions = Object.fromEntries(modelDefinitionsMap)
     const properties = Object.fromEntries(modelPropertyDefinitionsMap)

--- a/src/generator/types.ts
+++ b/src/generator/types.ts
@@ -11,3 +11,7 @@ export interface ModelMetaData {
 
 export type DefinitionMap = [name: string, definition: JSONSchema7Definition]
 export type PropertyMap = [...DefinitionMap, PropertyMetaData]
+
+export interface TransformOptions {
+    keepRelationScalarFields?: 'true' | 'false'
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ generatorHandler({
         }
     },
     async onGenerate(options) {
-        const jsonSchema = transformDMMF(options.dmmf)
+        const jsonSchema = transformDMMF(options.dmmf, options.generator.config)
         if (options.generator.output) {
             const outputDir =
                 // This ensures previous version of prisma are still supported

--- a/src/tests/generator.test.ts
+++ b/src/tests/generator.test.ts
@@ -94,6 +94,73 @@ describe('JSON Schema Generator', () => {
         })
     })
 
+    it('keeps relation scalar fields if requested', async () => {
+        const dmmf = await getDMMF({ datamodel })
+        expect(
+            transformDMMF(dmmf, { keepRelationScalarFields: 'true' }),
+        ).toEqual({
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            definitions: {
+                Post: {
+                    properties: {
+                        id: { type: 'integer' },
+                        user: {
+                            anyOf: [
+                                { $ref: '#/definitions/User' },
+                                { type: 'null' },
+                            ],
+                        },
+                        userId: {
+                            type: ['integer', 'null'],
+                        },
+                    },
+                    type: 'object',
+                },
+                User: {
+                    properties: {
+                        biography: { type: 'object' },
+                        createdAt: { format: 'date-time', type: 'string' },
+                        email: { type: 'string' },
+                        id: { type: 'integer' },
+                        is18: { type: ['boolean', 'null'] },
+                        keywords: {
+                            items: { type: 'string' },
+                            type: 'array',
+                        },
+                        name: { type: ['string', 'null'] },
+                        posts: {
+                            items: { $ref: '#/definitions/Post' },
+                            type: 'array',
+                        },
+                        predecessor: {
+                            anyOf: [
+                                { $ref: '#/definitions/User' },
+                                { type: 'null' },
+                            ],
+                        },
+                        role: { enum: ['USER', 'ADMIN'], type: 'string' },
+                        successor: {
+                            anyOf: [
+                                { $ref: '#/definitions/User' },
+                                { type: 'null' },
+                            ],
+                        },
+                        successorId: {
+                            type: ['integer', 'null'],
+                        },
+                        weight: { type: ['number', 'null'] },
+                    },
+                    type: 'object',
+                },
+            },
+            properties: {
+                post: { $ref: '#/definitions/Post' },
+                user: { $ref: '#/definitions/User' },
+            },
+            type: 'object',
+        })
+    })
+
     // eslint-disable-next-line jest/expect-expect
     it('generated schema validates against input', async () => {
         const dmmf = await getDMMF({ datamodel })


### PR DESCRIPTION
I had a need to maintain the relational foreign keys in my json schema.

Would you consider a PR like this to make it optional?

I saw someone else was trying to do something similar in #24