### PR TITLE
add bigint as PrismaPrimitive option

### DIFF
--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -4,6 +4,7 @@ export type PrismaPrimitive =
     | 'String'
     | 'Boolean'
     | 'Int'
+    | 'BigInt'
     | 'Float'
     | 'Json'
     | 'DateTime'


### PR DESCRIPTION
Adding support to BigInt to avoid this error:

![image](https://user-images.githubusercontent.com/232648/127380797-72af42a3-fb54-43f5-bc67-ebe2d21598df.png)
