### PR TITLE
feat: add id with references on schema

### DIFF
--- a/src/generator/constants.ts
+++ b/src/generator/constants.ts
@@ -1,1 +1,2 @@
 export const DEFINITIONS_ROOT = '#/definitions/'
+export const JSON_SCHEMA_ID = 'prisma-json-schema'

--- a/src/generator/jsonSchema.ts
+++ b/src/generator/jsonSchema.ts
@@ -1,6 +1,8 @@
 import { JSONSchema7 } from 'json-schema'
+import { JSON_SCHEMA_ID } from './constants'
 
 export const getInitialJSON = (): JSONSchema7 => ({
+    $id: JSON_SCHEMA_ID,
     $schema: 'http://json-schema.org/draft-07/schema#',
     definitions: {},
     type: 'object',

--- a/src/generator/properties.ts
+++ b/src/generator/properties.ts
@@ -1,18 +1,18 @@
 import { DMMF } from '@prisma/generator-helper'
-import { DEFINITIONS_ROOT } from './constants'
+import type {
+    JSONSchema7,
+    JSONSchema7Definition,
+    JSONSchema7TypeName
+} from 'json-schema'
+import { DEFINITIONS_ROOT, JSON_SCHEMA_ID } from './constants'
 import {
     assertNever,
     isEnumType,
     isScalarType,
-    PrismaPrimitive,
+    PrismaPrimitive
 } from './helpers'
 import { ModelMetaData, PropertyMap, PropertyMetaData } from './types'
 
-import type {
-    JSONSchema7,
-    JSONSchema7Definition,
-    JSONSchema7TypeName,
-} from 'json-schema'
 
 function getJSONSchemaScalar(fieldType: PrismaPrimitive): JSONSchema7TypeName {
     switch (fieldType) {
@@ -60,7 +60,7 @@ function getFormatByDMMFType(fieldType: string): string | undefined {
 
 function getJSONSchemaForPropertyReference(field: DMMF.Field): JSONSchema7 {
     const notNullable = field.isRequired || field.isList
-    const ref = { $ref: `${DEFINITIONS_ROOT}${field.type}` }
+    const ref = { $ref: `${JSON_SCHEMA_ID}${DEFINITIONS_ROOT}${field.type}` }
     return notNullable ? ref : { anyOf: [ref, { type: 'null' }] }
 }
 

--- a/src/generator/transformDMMF.ts
+++ b/src/generator/transformDMMF.ts
@@ -1,11 +1,11 @@
 import type { DMMF } from '@prisma/generator-helper'
 import type { JSONSchema7, JSONSchema7Definition } from 'json-schema'
-import { TransformOptions } from './types'
-import { DEFINITIONS_ROOT } from './constants'
+import { DEFINITIONS_ROOT, JSON_SCHEMA_ID } from './constants'
 import { toCamelCase } from './helpers'
-
 import { getInitialJSON } from './jsonSchema'
 import { getJSONSchemaModel } from './model'
+import { TransformOptions } from './types'
+
 
 function getPropertyDefinition(
     model: DMMF.Model,
@@ -13,7 +13,7 @@ function getPropertyDefinition(
     return [
         toCamelCase(model.name),
         {
-            $ref: `${DEFINITIONS_ROOT}${model.name}`,
+            $ref: `${JSON_SCHEMA_ID}${DEFINITIONS_ROOT}${model.name}`,
         },
     ]
 }

--- a/src/tests/generator.test.ts
+++ b/src/tests/generator.test.ts
@@ -1,7 +1,7 @@
 import { getDMMF } from '@prisma/sdk'
-import { transformDMMF } from '../generator/transformDMMF'
 import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
+import { transformDMMF } from '../generator/transformDMMF'
 
 const datamodel = /* Prisma */ `
 	datasource db {
@@ -44,6 +44,7 @@ describe('JSON Schema Generator', () => {
     it('returns JSON Schema for given models', async () => {
         const dmmf = await getDMMF({ datamodel })
         expect(transformDMMF(dmmf)).toEqual({
+            $id: 'prisma-json-schema',
             $schema: 'http://json-schema.org/draft-07/schema#',
             definitions: {
                 Post: {
@@ -51,7 +52,7 @@ describe('JSON Schema Generator', () => {
                         id: { type: 'integer' },
                         user: {
                             anyOf: [
-                                { $ref: '#/definitions/User' },
+                                { $ref: 'prisma-json-schema#/definitions/User' },
                                 { type: 'null' },
                             ],
                         },
@@ -71,19 +72,19 @@ describe('JSON Schema Generator', () => {
                         keywords: { items: { type: 'string' }, type: 'array' },
                         name: { type: ['string', 'null'] },
                         posts: {
-                            items: { $ref: '#/definitions/Post' },
+                            items: { $ref: 'prisma-json-schema#/definitions/Post' },
                             type: 'array',
                         },
                         predecessor: {
                             anyOf: [
-                                { $ref: '#/definitions/User' },
+                                { $ref: 'prisma-json-schema#/definitions/User' },
                                 { type: 'null' },
                             ],
                         },
                         role: { enum: ['USER', 'ADMIN'], type: 'string' },
                         successor: {
                             anyOf: [
-                                { $ref: '#/definitions/User' },
+                                { $ref: 'prisma-json-schema#/definitions/User' },
                                 { type: 'null' },
                             ],
                         },
@@ -93,8 +94,8 @@ describe('JSON Schema Generator', () => {
                 },
             },
             properties: {
-                post: { $ref: '#/definitions/Post' },
-                user: { $ref: '#/definitions/User' },
+                post: { $ref: 'prisma-json-schema#/definitions/Post' },
+                user: { $ref: 'prisma-json-schema#/definitions/User' },
             },
             type: 'object',
         })
@@ -105,6 +106,7 @@ describe('JSON Schema Generator', () => {
         expect(
             transformDMMF(dmmf, { keepRelationScalarFields: 'true' }),
         ).toEqual({
+            $id: 'prisma-json-schema',
             $schema: 'http://json-schema.org/draft-07/schema#',
             definitions: {
                 Post: {
@@ -112,7 +114,7 @@ describe('JSON Schema Generator', () => {
                         id: { type: 'integer' },
                         user: {
                             anyOf: [
-                                { $ref: '#/definitions/User' },
+                                { $ref: 'prisma-json-schema#/definitions/User' },
                                 { type: 'null' },
                             ],
                         },
@@ -138,19 +140,19 @@ describe('JSON Schema Generator', () => {
                         },
                         name: { type: ['string', 'null'] },
                         posts: {
-                            items: { $ref: '#/definitions/Post' },
+                            items: { $ref: 'prisma-json-schema#/definitions/Post' },
                             type: 'array',
                         },
                         predecessor: {
                             anyOf: [
-                                { $ref: '#/definitions/User' },
+                                { $ref: 'prisma-json-schema#/definitions/User' },
                                 { type: 'null' },
                             ],
                         },
                         role: { enum: ['USER', 'ADMIN'], type: 'string' },
                         successor: {
                             anyOf: [
-                                { $ref: '#/definitions/User' },
+                                { $ref: 'prisma-json-schema#/definitions/User' },
                                 { type: 'null' },
                             ],
                         },
@@ -163,8 +165,8 @@ describe('JSON Schema Generator', () => {
                 },
             },
             properties: {
-                post: { $ref: '#/definitions/Post' },
-                user: { $ref: '#/definitions/User' },
+                post: { $ref: 'prisma-json-schema#/definitions/Post' },
+                user: { $ref: 'prisma-json-schema#/definitions/User' },
             },
             type: 'object',
         })


### PR DESCRIPTION
#73 Hi,

This is my PR to add an id to the generated schema. I hardcoded it in `constants.ts` as `prisma-json-schema`.
I also had to update the generated refs for it to work properly if we have to reference the file.
Now, people cam generated schemas and extend it with refs/merge/patch keyword without problems.

Thanks for this library mate ;)