### PR TITLE
Added yaml conversion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ generator jsonSchema {
   schemaId = "some-schema-id"
   includeRequiredFields = "true"
   persistOriginalType = "true"
+  toYaml = "false"
 }
 ```
 
@@ -62,6 +63,7 @@ The generator currently supports a few options
 | schemaId                 | undefined     | Add an id to the generated schema. All references will include the schema id                                                                                                                           |
 | includeRequiredFields    | "false"       | If this flag is `"true"` all required scalar prisma fields that do not have a default value, will be added to the `required` properties field for that schema definition.                              |
 | persistOriginalType      | "false"       | If this flag is `"true"` the original type will be outputed under the property key "originalType"                                                                                                      |
+| toYaml    | "false"       | If this flag is `"true"` the output will be a yaml file. _(The JSON schema is simply converted into YAML and outputed.)_                              |
 
 **3. Run generation**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,8 @@
                 "prettier": "2.8.8",
                 "prisma": "4.16.2",
                 "semantic-release": "19.0.3",
-                "typescript": "5.1.6"
+                "typescript": "5.1.6",
+                "yaml": "^2.3.1"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -3946,6 +3947,15 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/cosmiconfig/node_modules/yaml": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/crc-32": {
@@ -12269,12 +12279,12 @@
             "dev": true
         },
         "node_modules/yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+            "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
             "dev": true,
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/yargs": {
@@ -15312,6 +15322,14 @@
                 "parse-json": "^5.0.0",
                 "path-type": "^4.0.0",
                 "yaml": "^1.10.0"
+            },
+            "dependencies": {
+                "yaml": {
+                    "version": "1.10.2",
+                    "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+                    "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+                    "dev": true
+                }
             }
         },
         "crc-32": {
@@ -21442,9 +21460,9 @@
             "dev": true
         },
         "yaml": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+            "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
             "dev": true
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
         "prettier": "2.8.8",
         "prisma": "4.16.2",
         "semantic-release": "19.0.3",
-        "typescript": "5.1.6"
+        "typescript": "5.1.6",
+        "yaml": "^2.3.1"
     },
     "scripts": {
         "generate": "prisma generate",

--- a/prisma/json-schema/yaml-schema.yaml
+++ b/prisma/json-schema/yaml-schema.yaml
@@ -1,0 +1,68 @@
+definitions:
+  User:
+    type: object
+    properties:
+      id:
+        type: integer
+      createdAt:
+        type: string
+        format: date-time
+      email:
+        type: string
+      weight:
+        type:
+          - number
+          - "null"
+      is18:
+        type:
+          - boolean
+          - "null"
+      name:
+        type:
+          - string
+          - "null"
+      successor:
+        anyOf:
+          - $ref: "#/definitions/User"
+          - type: "null"
+      predecessor:
+        anyOf:
+          - $ref: "#/definitions/User"
+          - type: "null"
+      role:
+        type: string
+        default: USER
+        enum:
+          - USER
+          - ADMIN
+      posts:
+        type: array
+        items:
+          $ref: "#/definitions/Post"
+      keywords:
+        type: array
+        items:
+          type: string
+      biography:
+        type:
+          - number
+          - string
+          - boolean
+          - object
+          - array
+          - "null"
+  Post:
+    type: object
+    properties:
+      id:
+        type: integer
+      user:
+        anyOf:
+          - $ref: "#/definitions/User"
+          - type: "null"
+type: object
+properties:
+  user:
+    $ref: "#/definitions/User"
+  post:
+    $ref: "#/definitions/Post"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,7 +18,7 @@ model User {
   weight      Float?
   is18        Boolean?
   name        String?
-  successorId Int?
+  successorId Int?     @unique
   successor   User?    @relation("BlogOwnerHistory", fields: [successorId], references: [id])
   predecessor User?    @relation("BlogOwnerHistory")
   role        Role     @default(USER)

--- a/src/generator/types.ts
+++ b/src/generator/types.ts
@@ -19,4 +19,5 @@ export interface TransformOptions {
     schemaId?: string
     includeRequiredFields?: 'true' | 'false'
     persistOriginalType?: 'true' | 'false'
+    toYaml?: 'true' | 'false'
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { transformDMMF } from './generator/transformDMMF'
 import * as fs from 'fs'
 import * as path from 'path'
 import { parseEnvValue } from '@prisma/internals'
+import YAML from 'yaml'
 
 generatorHandler({
     onManifest() {
@@ -24,10 +25,17 @@ generatorHandler({
                 await fs.promises.mkdir(outputDir, {
                     recursive: true,
                 })
-                await fs.promises.writeFile(
-                    path.join(outputDir, 'json-schema.json'),
-                    JSON.stringify(jsonSchema, null, 2),
-                )
+                if (options.generator.config.toYaml) {
+                    await fs.promises.writeFile(
+                        path.join(outputDir, 'yaml-schema.yaml'),
+                        YAML.stringify({ ...jsonSchema, $schema: undefined }),
+                    )
+                } else {
+                    await fs.promises.writeFile(
+                        path.join(outputDir, 'json-schema.json'),
+                        JSON.stringify(jsonSchema, null, 2),
+                    )
+                }
             } catch (e) {
                 console.error(
                     'Error: unable to write files for Prisma Schema Generator',


### PR DESCRIPTION
Added an additional option `toYaml` which could be `true | false`, which is by default `false`, when `true` the json schema is converted to yaml and outputted as yaml file.


These yaml files can be used with [swagger-jsdoc](https://www.npmjs.com/package/swagger-jsdoc), just a minor feature which is handy 😄 