### PR TITLE
Fix anyOf format

### DIFF
--- a/src/generator/properties.ts
+++ b/src/generator/properties.ts
@@ -202,7 +202,7 @@ function getPropertyDefinition(
             originalType: field.type,
         }),
         ...(isDefined(defaultValue) && { default: defaultValue }),
-        ...(isDefined(format) && !convertUnionType.anyOf && { format }),
+        ...(isDefined(format) && !convertedUnion.anyOf && { format }),
         ...(isDefined(items) && { items }),
         ...(isDefined(enumList) && { enum: enumList }),
         ...(isDefined(description) && { description }),

--- a/src/generator/properties.ts
+++ b/src/generator/properties.ts
@@ -162,7 +162,7 @@ function getDescription(field: DMMF.Field) {
 function convertUnionType(
     forceAnyOf: 'true' | 'false' | undefined,
     type: JSONSchema7['type'],
-    format: string | undefined
+    format: string | undefined,
 ): JSONSchema7 {
     if (forceAnyOf !== 'true') {
         return { type }
@@ -171,7 +171,12 @@ function convertUnionType(
     if (!isUnionType) {
         return { type }
     }
-    return { anyOf: type.map((t) => ({ type: t, ...(isDefined(format) && type !== "null" && { format }) })) }
+    return {
+        anyOf: type.map((t) => ({
+            type: t,
+            ...(isDefined(format) && type !== 'null' && { format }),
+        })),
+    }
 }
 
 function getPropertyDefinition(
@@ -185,7 +190,11 @@ function getPropertyDefinition(
     const enumList = getEnumListByDMMFType(modelMetaData)(field)
     const defaultValue = getDefaultValue(field)
     const description = getDescription(field)
-    const convertedUnion = convertUnionType(transformOptions.forceAnyOf, type, format)
+    const convertedUnion = convertUnionType(
+        transformOptions.forceAnyOf,
+        type,
+        format,
+    )
 
     const definition: JSONSchema7Definition = {
         ...convertedUnion,

--- a/src/generator/properties.ts
+++ b/src/generator/properties.ts
@@ -174,7 +174,7 @@ function convertUnionType(
     return {
         anyOf: type.map((t) => ({
             type: t,
-            ...(isDefined(format) && type !== 'null' && { format }),
+            ...(isDefined(format) && t !== 'null' && { format }),
         })),
     }
 }

--- a/src/tests/generator.test.ts
+++ b/src/tests/generator.test.ts
@@ -1106,7 +1106,9 @@ describe('JSON Schema Generator', () => {
         })
 
         it('nullable anyOf field', async () => {
-            const dmmf = await getDMMF({ datamodel: datamodelPostGresQL_anyOfCheck })
+            const dmmf = await getDMMF({
+                datamodel: datamodelPostGresQL_anyOfCheck,
+            })
             const jsonSchema = transformDMMF(dmmf, {
                 forceAnyOf: 'true',
             })

--- a/src/tests/generator.test.ts
+++ b/src/tests/generator.test.ts
@@ -60,6 +60,18 @@ const datamodelMongoDB = /* Prisma */ `
   }
 `
 
+const datamodelPostGresQL_anyOfCheck = /* Prisma */ `
+	datasource db {
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
+  }
+
+  model Article {
+    id        Int       @id @default(autoincrement())
+    expiredAt DateTime? @default(now())
+  }
+`
+
 describe('JSON Schema Generator', () => {
     describe('db postgresql', () => {
         it('returns JSON Schema for given models', async () => {
@@ -1091,6 +1103,34 @@ describe('JSON Schema Generator', () => {
             if (!valid) {
                 throw new Error(ajv.errorsText(validate.errors))
             }
+        })
+
+        it('nullable anyOf field', async () => {
+            const dmmf = await getDMMF({ datamodel: datamodelPostGresQL_anyOfCheck })
+            const jsonSchema = transformDMMF(dmmf, {
+                forceAnyOf: 'true',
+            })
+            expect(jsonSchema).toEqual({
+                $schema: 'http://json-schema.org/draft-07/schema#',
+                definitions: {
+                    Article: {
+                        properties: {
+                            id: { type: 'integer' },
+                            expiredAt: {
+                                anyOf: [
+                                    { type: 'string', format: 'date-time' },
+                                    { type: 'null' },
+                                ],
+                            },
+                        },
+                        type: 'object',
+                    },
+                },
+                properties: {
+                    article: { $ref: '#/definitions/Article' },
+                },
+                type: 'object',
+            })
         })
     })
 


### PR DESCRIPTION
Hey,

I noticed some warnings from my Fastify on some Date fields from my Prisma generated schemas. After some investigation, I found that when we have a properties with several possible types (with the `anyOf` key), for example a nullable Date, the generator do it wrong, because it put the `"format": "date-time"` outside the `anyOf` key, which is not correct.

I made 2 tiny changes to remove the `format` key of the property root if there is a `anyOf` key, and add the `format` inside the `anyOf` if there's one, except for the `null` type.